### PR TITLE
Fix example_transaction.py

### DIFF
--- a/example_transaction.py
+++ b/example_transaction.py
@@ -1,6 +1,9 @@
-from web3.auto import w3
+from web3 import Web3
 import json
 import ruamel.yaml as yaml
+
+provider = Web3.HTTPProvider('http://localhost:8545')
+w3 = Web3(provider)
 
 w3.eth.account.enable_unaudited_hdwallet_features()
 
@@ -8,14 +11,14 @@ with open("mergenet.yaml") as stream:
     data = yaml.safe_load(stream)
 
 src_acct = w3.eth.account.from_mnemonic(
-    data['mnemonic'], account_path=data['eth1_premine'].keys()[0], passphrase='')
+    data['mnemonic'], account_path=list(data['eth1_premine'].keys())[0], passphrase='')
 
 dest_acct = w3.eth.account.from_mnemonic(
-    data['mnemonic'], account_path=data['eth1_premine'].keys()[1], passphrase='')
+    data['mnemonic'], account_path=list(data['eth1_premine'].keys())[1], passphrase='')
 
 transaction = {
     'to': dest_acct.address,
-    'value': 1 * 1e18,
+    'value': w3.toWei(1, 'ether'),
     'gas': 21000,
     'gasPrice': 4,
     'nonce': 0,


### PR DESCRIPTION
Addresses some issues with `example_transaction.py`


### Error 1

Needed to put the `keys()` call into a list:

```
Traceback (most recent call last):
  File "/home/paul/development/mergenet-tutorial/example_transaction.py", line 11, in <module>
    data['mnemonic'], account_path=data['eth1_premine'].keys()[0], passphrase='')
TypeError: 'dict_keys' object is not subscriptable
```

### Error 2

Transaction value was using scientific notation:

```
signing transaction:
{
  "to": "0x4A776E9369831F50564E430AACdD58b6bE78A10b",
  "value": 1e+18,
  "gas": 21000,
  "gasPrice": 4,
  "nonce": 0,
  "chainId": 700
}
Traceback (most recent call last):
  File "/home/paul/development/mergenet-tutorial/example_transaction.py", line 32, in <module>
    signed_transaction = src_acct.sign_transaction(transaction)
  File "/home/paul/development/mergenet-tutorial/venv/lib/python3.9/site-packages/eth_account/signers/local.py", line 93, in sign_transaction
    return self._publicapi.sign_transaction(transaction_dict, self.key)
  File "/home/paul/development/mergenet-tutorial/venv/lib/python3.9/site-packages/eth_utils/decorators.py", line 18, in _wrapper
    return self.method(obj, *args, **kwargs)
  File "/home/paul/development/mergenet-tutorial/venv/lib/python3.9/site-packages/eth_account/account.py", line 667, in sign_transaction
    ) = sign_transaction_dict(account._key_obj, sanitized_transaction)
  File "/home/paul/development/mergenet-tutorial/venv/lib/python3.9/site-packages/eth_account/_utils/signing.py", line 28, in sign_transaction_dict
    unsigned_transaction = serializable_unsigned_transaction_from_dict(transaction_dict)
  File "/home/paul/development/mergenet-tutorial/venv/lib/python3.9/site-packages/eth_account/_utils/transactions.py", line 43, in serializable_unsigned_transaction_from_dict
    assert_valid_fields(transaction_dict)
  File "/home/paul/development/mergenet-tutorial/venv/lib/python3.9/site-packages/eth_account/_utils/transactions.py", line 147, in assert_valid_fields
    raise TypeError("Transaction had invalid fields: %r" % invalid)
TypeError: Transaction had invalid fields: {'value': 1e+18}
```

### Error 3

The `web3.auto` call seems to use `web3_clientVersion` which Geth doesn't like:

```
WARN [04-20|17:10:10.117] Served web3_clientVersion                conn=127.0.0.1:59184 reqid=0 t="10.55µs" err="the method web3_clientVersion does not exist/is not available"
```

```
signing transaction:
{
  "to": "0x4A776E9369831F50564E430AACdD58b6bE78A10b",
  "value": 1000000000000000000,
  "gas": 21000,
  "gasPrice": 4,
  "nonce": 0,
  "chainId": 700
}
Traceback (most recent call last):
  File "/home/paul/development/mergenet-tutorial/example_transaction.py", line 30, in <module>
    tx_hash = w3.eth.send_raw_transaction(signed_transaction.rawTransaction)
  File "/home/paul/development/mergenet-tutorial/venv/lib/python3.9/site-packages/web3/module.py", line 58, in caller
    result = w3.manager.request_blocking(method_str, params, error_formatters)
  File "/home/paul/development/mergenet-tutorial/venv/lib/python3.9/site-packages/web3/manager.py", line 154, in request_blocking
    response = self._make_request(method, params)
  File "/home/paul/development/mergenet-tutorial/venv/lib/python3.9/site-packages/web3/manager.py", line 133, in _make_request
    return request_func(method, params)
  File "cytoolz/functoolz.pyx", line 250, in cytoolz.functoolz.curry.__call__
  File "/home/paul/development/mergenet-tutorial/venv/lib/python3.9/site-packages/web3/middleware/formatting.py", line 76, in apply_formatters
    response = make_request(method, params)
  File "/home/paul/development/mergenet-tutorial/venv/lib/python3.9/site-packages/web3/middleware/gas_price_strategy.py", line 34, in middleware
    return make_request(method, params)
  File "cytoolz/functoolz.pyx", line 250, in cytoolz.functoolz.curry.__call__
  File "/home/paul/development/mergenet-tutorial/venv/lib/python3.9/site-packages/web3/middleware/formatting.py", line 74, in apply_formatters
    response = make_request(method, formatted_params)
  File "/home/paul/development/mergenet-tutorial/venv/lib/python3.9/site-packages/web3/middleware/attrdict.py", line 33, in middleware
    response = make_request(method, params)
  File "cytoolz/functoolz.pyx", line 250, in cytoolz.functoolz.curry.__call__
  File "/home/paul/development/mergenet-tutorial/venv/lib/python3.9/site-packages/web3/middleware/formatting.py", line 76, in apply_formatters
    response = make_request(method, params)
  File "/home/paul/development/mergenet-tutorial/venv/lib/python3.9/site-packages/web3/middleware/normalize_errors.py", line 25, in middleware
    result = make_request(method, params)
  File "cytoolz/functoolz.pyx", line 250, in cytoolz.functoolz.curry.__call__
  File "/home/paul/development/mergenet-tutorial/venv/lib/python3.9/site-packages/web3/middleware/formatting.py", line 76, in apply_formatters
    response = make_request(method, params)
  File "cytoolz/functoolz.pyx", line 250, in cytoolz.functoolz.curry.__call__
  File "/home/paul/development/mergenet-tutorial/venv/lib/python3.9/site-packages/web3/middleware/formatting.py", line 74, in apply_formatters
    response = make_request(method, formatted_params)
  File "/home/paul/development/mergenet-tutorial/venv/lib/python3.9/site-packages/web3/providers/auto.py", line 94, in make_request
    return self._proxy_request(method, params)
  File "/home/paul/development/mergenet-tutorial/venv/lib/python3.9/site-packages/web3/providers/auto.py", line 104, in _proxy_request
    provider = self._get_active_provider(use_cache)
  File "/home/paul/development/mergenet-tutorial/venv/lib/python3.9/site-packages/web3/providers/auto.py", line 121, in _get_active_provider
    if provider is not None and provider.isConnected():
  File "/home/paul/development/mergenet-tutorial/venv/lib/python3.9/site-packages/web3/providers/base.py", line 108, in isConnected
    assert 'error' not in response
AssertionError
```