### PR TITLE
Remove Quotes from ETH2 Config for Prysm

### DIFF
--- a/generate_eth2_conf.py
+++ b/generate_eth2_conf.py
@@ -99,7 +99,7 @@ EFFECTIVE_BALANCE_INCREMENT: 1000000000
 
 # Initial values
 # ---------------------------------------------------------------
-GENESIS_FORK_VERSION: "{data['eth2_fork_version']}"
+GENESIS_FORK_VERSION: {data['eth2_fork_version']}
 
 BLS_WITHDRAWAL_PREFIX: 0x00
 
@@ -160,7 +160,7 @@ DOMAIN_AGGREGATE_AND_PROOF: 0x06000000
 # Merge
 # ---------------------------------------------------------------
 # Same fork version as genesis, since there is no actual fork
-MERGE_FORK_VERSION: "{data['eth2_fork_version']}"
+MERGE_FORK_VERSION: {data['eth2_fork_version']}
 # Merge active from genesis
 MERGE_FORK_SLOT: 0
 


### PR DESCRIPTION
Prysm does not like hex values in quoted strings, and it seems like the genesis fork versions are unnecessarily quoted after yaml generation in the python tool. This PR removes the unnecessary quotes.

@protolambda is there a reason these config values are quoted right now?