### PR TITLE
Provide a docker environment to run config generation cmds.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu:20.10
+RUN apt-get update
+RUN apt-get install -y tzdata
+
+RUN apt-get install -y python3-dev python3-venv python3-pip
+RUN python3 -m venv /venv
+COPY requirements.txt /requirements.txt
+RUN /venv/bin/pip install -r /requirements.txt
+ENV PATH=$PATH:/venv/bin VIRTUAL_ENV=/venv
+
+RUN apt-get install -y curl
+RUN curl https://dl.google.com/go/go1.16.3.linux-amd64.tar.gz | tar -xz -C /usr/local
+ENV PATH=$PATH:/usr/local/gopath/bin:/usr/local/go/bin GOPATH=/usr/local/gopath
+
+RUN go install github.com/protolambda/eth2-testnet-genesis@latest
+RUN go install github.com/protolambda/eth2-val-tools@latest

--- a/README.md
+++ b/README.md
@@ -2,11 +2,21 @@
 
 Let's set up a local eth1-eth2 merge testnet!
 
-## Pre-requisites install
+## Preparing the setup environment
 
-Note: *Python (incl. `python-dev`) and Go (1.16+) standard installs assumed*
+In this tutorial, we use a series of scripts to generate configuration
+files, and these scripts have dependencies that we need to
+install. You can either install these dependencies on your host or you
+can run those scripts inside a docker container. We call this
+environment setupenv.
 
+Preparing the setup environment on your host:
 ```shell
+apt-get install python3-dev python3-pip python3-venv golang
+
+# Check that you have Go 1.16+ installed
+go version
+
 # Create, start and install python venv
 python -m venv venv 
 . venv/bin/activate
@@ -16,6 +26,19 @@ pip install -r requirements.txt
 go install github.com/protolambda/eth2-testnet-genesis@latest
 # Install eth2-val-tools
 go install github.com/protolambda/eth2-val-tools@latest
+# You are now in the right directory to run the setupenv commands below.
+```
+
+Alternatively, you can use docker:
+```shell
+docker build -t setupenv .
+docker run -i -v $PWD:/mergenet-tutorial \
+  -v /etc/passwd:/etc/passwd -h setupenv \
+  -u $(id -u):$(id -g) -t setupenv \
+  /bin/bash
+# docker spawns a shell and inside that run:
+cd /mergenet-tutorial
+# You are now in the right directory to run the setupenv commands below.
 ```
 
 ## Create chain configurations
@@ -28,11 +51,9 @@ date +%s
 ```
 
 ```shell
-# Create output
+# Inside your setupenv: Generate ETH1/ETH2 configs
 export TESTNET_NAME="mynetwork"
-mkdir "$TESTNET_NAME"
-mkdir "$TESTNET_NAME/public"
-mkdir "$TESTNET_NAME/private"
+mkdir -p "$TESTNET_NAME/public" "$TESTNET_NAME/private"
 # Configure Eth1 chain
 python generate_eth1_conf.py > "$TESTNET_NAME/public/eth1_config.json"
 # Configure Eth2 chain
@@ -45,7 +66,7 @@ Make sure that total of `count` entries is more than the configured `MIN_GENESIS
 
 ## Prepare Eth2 data
 ```shell
-# Generate Genesis Beacon State
+# Inside your setupenv: Generate Genesis Beacon State
 eth2-testnet-genesis merge \
   --eth1-config "$TESTNET_NAME/public/eth1_config.json" \
   --eth2-config "$TESTNET_NAME/public/eth2_config.yaml" \
@@ -86,7 +107,6 @@ You can choose to run clients in two ways:
 
 The docker instructions include how to configure each of the clients. 
 Substitute docker volume-mounts with your own directory layout choices, the instructions are otherwise the same. 
-
 
 ## Genesis
 

--- a/from_docker.md
+++ b/from_docker.md
@@ -107,7 +107,9 @@ docker run \
 nethermind/nethermind:latest
 ```
 #### Generate config
-```
+
+```shell
+# Inside your setupenv, run
 python generate_eth1_nethermind_conf.py > "$TESTNET_NAME/public/eth1_nethermind_config.json"
 ```
 


### PR DESCRIPTION
There are certain pitfalls with installing the Python3
requirements.txt on other distributions. For instance on the most
recent Debian (buster), we see bdist_wheel failures during pip
install, and the installed Go version is too old. It is much more
convenient and reliable to also use docker to generate configs.