### PR TITLE
Add deposit instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,16 @@ eth2-testnet-genesis merge \
 #
 # You can change the range of validator accounts, to split keys between nodes.
 # The mnemonic and key-range should match that of a tranche of validators in the beacon-state genesis.
+#
+# If you plan to test deposits make sure to generate more keystores here than
+# `count` in `genesis_validators.yaml`.
+
 export VALIDATOR_NODE_NAME="valclient0"
 eth2-val-tools keystores \
   --out-loc "$TESTNET_NAME/private/$VALIDATOR_NODE_NAME" \
   --prysm-pass="foobar" \
   --source-min=0 \
-  --source-max=64 \
+  --source-max=76 \
   --source-mnemonic="lumber kind orange gold firm achieve tree robust peasant april very word ordinary before treat way ivory jazz cereal debate juice evil flame sadness"
 ```
 
@@ -103,7 +107,19 @@ Run `example_transaction.py`.
 
 ### Test deposit
 
-TODO
+```shell
+
+# Generate the deposit data
+
+eth2-val-tools deposit-data --source-min 64 --source-max 76 \
+  --fork-version 0x00000700 \
+  --validators-mnemonic "lumber kind orange gold firm achieve tree robust peasant april very word ordinary before treat way ivory jazz cereal debate juice evil flame sadness" \
+  --withdrawals-mnemonic="bulk monster between urge hidden device play live island ankle resist pilot design only choice oppose know invest surge nerve voice holiday safe airport" \
+  > "$TESTNET_NAME"/private/$VALIDATOR_NODE_NAME/depositdata
+
+# Submit the deposits
+python send_deposits.py
+```
 
 ### Test contract deployment
 

--- a/send_deposits.py
+++ b/send_deposits.py
@@ -1,0 +1,55 @@
+from web3 import Web3
+import json
+import ruamel.yaml as yaml
+import os
+
+testnet_name = os.environ['TESTNET_NAME']
+validator_node_name = os.environ['VALIDATOR_NODE_NAME']
+
+#Adjust this to your eth1 endpoint
+provider = Web3.HTTPProvider('http://localhost:8545')
+
+w3 = Web3(provider)
+
+w3.eth.account.enable_unaudited_hdwallet_features()
+
+with open("mergenet.yaml") as stream:
+    data = yaml.safe_load(stream)
+
+src_acct = w3.eth.account.from_mnemonic(
+    data['mnemonic'], account_path=list(data['eth1_premine'].keys())[0], passphrase='')
+
+nonce = w3.eth.getTransactionCount(src_acct.address)
+
+deposit_data_path = testnet_name + "/private/" + validator_node_name + "/depositdata"
+with open(deposit_data_path) as depositdata:
+    for line in depositdata:
+        depjson = json.loads(line)
+        depdata = "0x22895118" +\
+                  "0000000000000000000000000000000000000000000000000000000000000080"+\
+                  "00000000000000000000000000000000000000000000000000000000000000e0"+\
+                  "0000000000000000000000000000000000000000000000000000000000000120"+\
+                  depjson['deposit_data_root']+\
+                  "0000000000000000000000000000000000000000000000000000000000000030"+\
+                  depjson['pubkey']+\
+                  "00000000000000000000000000000000"+\
+                  "0000000000000000000000000000000000000000000000000000000000000020"+\
+                  depjson['withdrawal_credentials']+\
+                  "0000000000000000000000000000000000000000000000000000000000000060"+\
+                  depjson['signature']
+        transaction = {
+            'to': data['deposit_contract_address'],
+            'value': w3.toWei(depjson['value'], 'gwei'),
+            'gas': 95000,
+            'gasPrice': 4,
+            'nonce' : nonce,
+            'chainId': int(data['chain_id']),
+            'data': depdata
+        }
+        nonce += 1
+
+        signed_transaction = src_acct.sign_transaction(transaction)
+        tx_hash = w3.eth.send_raw_transaction(signed_transaction.rawTransaction)
+        print("Sent deposit for pubkey: {}".format(depjson['pubkey']))
+        print("tx hash: {}.".format(tx_hash.hex()))
+


### PR DESCRIPTION
Added minimal support to test deposits. The user needs to generate more keystores so that they are already imported by their validators. Then generates the depositdata using `eth2-val-tools` and finally submits the raw transactions using a script similar to `example_transaction.py`